### PR TITLE
Fix invalid end tag and infinite auth redirect loop when errors happen

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,7 +66,7 @@ definePageMeta({
                 <a href="https://www.texasosteo.org/about-us">About US</a>
               </li>
               <li>
-                <a href="https://www.texasosteo.org/osteo-101-bone-health"></a>
+                <a href="https://www.texasosteo.org/osteo-101-bone-health">
                   Osteo 101
                 </a>
               </li>

--- a/server/middleware/auth.global.ts
+++ b/server/middleware/auth.global.ts
@@ -18,6 +18,7 @@ const publicPaths: PathFilter[] = [
   { path: '/api/users/me' },
   { path: '/api/users', methods: ['POST'] },
   { path: '/resources' },
+  { path: '/__nuxt_error' }, // Needed to show errors properly
 ]
 
 /**


### PR DESCRIPTION
There was a bug where there would be an infinite redirect loop of `302`s when Nuxt gave a Vue parsing error. This fixes the error and the infinite loop